### PR TITLE
Fix: Added Row under "Account Actions"

### DIFF
--- a/UniversalClient/iPhone/Controllers/ViewEmpireProfileController.m
+++ b/UniversalClient/iPhone/Controllers/ViewEmpireProfileController.m
@@ -148,7 +148,7 @@ typedef enum {
 				return 3;
 				break;
 			case SECTION_ACCOUNT_ACTIONS:
-				return 4;
+				return 5;
 				break;
 			case SECTION_SELF_DESTRUCT:
 				return 1;


### PR DESCRIPTION
When the purchasing Essentia message was added, an additional row was
not added
